### PR TITLE
Feature/TAO-0019/Remove PHPUnit dependency

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 .DS_Store
+.idea

--- a/composer.json
+++ b/composer.json
@@ -26,9 +26,5 @@
         "zendframework/zend-ldap" : "2.*",
         "ext-ldap" : "*"
     },
-    "require-dev" : {
-        "phpunit/phpunit": "4.1.*",
-        "phpunit/php-code-coverage": "2.*"
-    },
     "minimum-stability" : "dev"
 }


### PR DESCRIPTION
Related to: [https://oat-sa.atlassian.net/browse/TAO-10019](https://oat-sa.atlassian.net/browse/TAO-10019)

Remove PHPUnit dependency from package:

- **require-dev** section was removed from the composer.json file;
- **.idea** folder was added to the .gitignore file.