### PR TITLE
Added code to support persisting of LDAP users

### DIFF
--- a/model/LdapUser.php
+++ b/model/LdapUser.php
@@ -33,230 +33,33 @@ use common_user_User;
 use core_kernel_classes_Resource;
 use core_kernel_classes_Property;
 use common_Logger;
-use SebastianBergmann\Exporter\Exception;
 
 class LdapUser extends common_user_User {
 
-    /** @var  array of configuration */
-    protected $configuration;
+    private $identifier;
 
-    /**
-     * @var array
-     */
-    protected $userRawParameters;
+    private $cache;
 
-    /**
-     * @var array
-     */
-    protected $userExtraParameters = array();
-
-    /**
-     * @var string
-     */
-    protected $identifier;
-
-    /** @var  array $roles */
-    protected $roles;
-
-    /**
-     * Array that contains the language code as a single string
-     *
-     * @var array
-     */
-    protected $languageUi = array(DEFAULT_LANG);
-
-    /**
-     * Array that contains the language code as a single string
-     *
-     * @var array
-     */
-    protected $languageDefLg = array(DEFAULT_LANG);
-
-
-    /**
-     * The mapping of custom parameter from ldap to TAO property
-     *
-     * @var array
-     */
-    protected $mapping;
-
-
-    public function __construct(array $mapping = null){
-        $this->mapping = $mapping;
-    }
-
-
-    /**
-     * @return array
-     */
-    public function getMapping()
+    public function __construct($id, $data)
     {
-        return $this->mapping;
+        $this->identifier = $id;
+        $this->cache = $data;
     }
 
-    /**
-     * Sets the language URI
-     *
-     * @param string $languageDefLgUri
-     */
-    public function setLanguageDefLg($languageDefLgUri)
+    public function getIdentifier()
     {
-        $this->languageDefLg = array((string)$languageDefLgUri);
-
-        return $this;
-    }
-
-    /**
-     * Returns the language code
-     *
-     * @return array
-     */
-    public function getLanguageDefLg()
-    {
-        return $this->languageDefLg;
-    }
-
-    /**
-     * @param $property string
-     * @param $value string
-     */
-    public function setUserParameter($property, $value){
-        $this->userRawParameters[$property] = $value;
-    }
-
-
-    public function getUserParameter($property) {
-        if (isset ($this->userRawParameters[$property] ) )
-            return $this->userRawParameters[$property];
-
-        return null;
-    }
-
-    /**
-     * @param array $params
-     * @return AuthKeyValueUser
-     */
-    public function setUserRawParameters(array $params)
-    {
-        $this->setRoles(array('http://www.tao.lu/Ontologies/TAO.rdf#DeliveryRole'));
-
-        // initialize parameter that should be set
-        isset($params['preferredlanguage']) ? $this->setLanguageUi($params['preferredlanguage']) : DEFAULT_LANG;
-        isset($params['preferredlanguage']) ? $this->setLanguageDefLg($params['preferredlanguage']) : DEFAULT_LANG;
-        isset($params['mail']) ? $this->setUserParameter(PROPERTY_USER_MAIL, $params['mail']) : '';
-        isset($params['displayname']) ? $this->setUserParameter(PROPERTY_USER_LASTNAME, $params['displayname']) : $this->setUserParameter(PROPERTY_USER_LASTNAME, $params['cn']) ;
-
-
-        $mapping = $this->getMapping();
-        foreach($params as $key => $value) {
-
-            if(! in_array($key, array('preferredlanguage','mail', 'displayname'))) {
-
-                if(array_key_exists($key, $mapping)){
-                    $this->setUserParameter($mapping[$key], $value);
-                }
-            }
-
-        }
-
-
-        return $this;
-    }
-
-    /**
-     * @return array
-     */
-    public function getUserRawParameters()
-    {
-        return $this->userRawParameters;
-    }
-
-
-    /**
-     * @param mixed $language
-     */
-    public function setLanguageUi($languageUri)
-    {
-        $this->languageUi = array((string)$languageUri);
-
-        return $this;
-    }
-
-    /**
-     * @return array
-     */
-    public function getLanguageUi()
-    {
-        return $this->languageUi;
-    }
-
-
-    /**
-     * @return string
-     */
-    public function getIdentifier(){
         return $this->identifier;
     }
 
-    /**
-     * @param $identifier
-     * @return $this
-     */
-    public function setIdentifier($identifier){
-        $this->identifier = $identifier;
-
-        return $this;
-    }
-
-
-    /**
-     * @param $property string
-     * @return array|null
-     */
     public function getPropertyValues($property)
     {
-        $returnValue = null;
-
-        switch ($property) {
-            case PROPERTY_USER_DEFLG :
-                $returnValue = $this->getLanguageDefLg();
-                break;
-            case PROPERTY_USER_UILG :
-                $returnValue = $this->getLanguageUi();
-                break;
-            case PROPERTY_USER_ROLES :
-                $returnValue = $this->getRoles();
-                break;
-            default:
-                $returnValue = array($this->getUserParameter($property));
-        }
-
-        return $returnValue;
+        return isset($this->cache[$property])
+            ? $this->cache[$property]
+            : array();
     }
 
 
-    /**
-     * Function that will refresh the parameters.
-     */
     public function refresh() {
+        return false;
     }
-
-
-    /**
-     * @return array
-     */
-    public function getRoles() {
-        return $this->roles;
-    }
-
-    /**
-     * @param array $roles
-     * @return $this
-     */
-    public function setRoles(array $roles ) {
-        $this->roles = $roles;
-
-        return $this;
-    }
-
 }

--- a/model/LdapUserFactory.php
+++ b/model/LdapUserFactory.php
@@ -35,7 +35,6 @@ use oat\taoTestTaker\models\CrudService;
 use oat\generis\model\user\UserRdf;
 
 
-
 class LdapUserFactory extends Configurable {
 
     public function createUser($rawData) {
@@ -59,16 +58,19 @@ class LdapUserFactory extends Configurable {
         $taouser = null;
 
         // check if login already exists - Create if not, and add the delivery role!
-        $userService = \core_kernel_users_Service::singleton();
+        // $userService = ServiceManager::getServiceManager()->get("tao/UserService");
+        // $userService = \tao_models_classes_UserService::singleton();
+        // $userService = \core_kernel_users_Service::singleton();
+        // $userService = tao_models_classes_UserService::singleton();
 
-        if (! $userService->loginExists($userdata[PROPERTY_USER_LOGIN])) {
-           $crudservice = new CrudService;
+        if (! \core_kernel_users_Service::loginExists($userdata[PROPERTY_USER_LOGIN])) {
+           $crudservice = CrudService::singleton();
            $taouser = $crudservice->CreateFromArray( $userdata );
 
         } else {
 
            // Retrieve the specified user.
-           $taouser = $userService->getOneUser( $userdata[PROPERTY_USER_LOGIN] );
+           $taouser = \core_kernel_users_Service::getOneUser( $userdata[PROPERTY_USER_LOGIN] );
         }
 
         return new LdapUser($taouser->getUri(), $data);

--- a/model/LdapUserFactory.php
+++ b/model/LdapUserFactory.php
@@ -1,0 +1,155 @@
+<?php
+/**
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; under version 2
+ * of the License (non-upgradable).
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ *
+ * Copyright (c) 2014 (original work) Open Assessment Technologies SA;
+ *
+ *
+ */
+
+/**
+ * Authentication user for key value db access
+ *
+ * @author christophe massin
+ * @package authLdap
+
+ */
+
+
+namespace oat\authLdap\model;
+
+use oat\oatbox\Configurable;
+use oat\taoTestTaker\models\CrudService;
+use oat\generis\model\user\UserRdf;
+
+
+
+class LdapUserFactory extends Configurable {
+
+    public function createUser($rawData) {
+
+        if (!isset($rawData['dn'])) {
+            throw new \common_exception_InconsistentData('Missing DN for LDAP user');
+        } else {
+            $id = $rawData['dn'];
+        }
+
+        $data = array();
+        $userdata = array();
+
+
+        foreach ($this->getRules() as $property => $rule) {
+            $data[$property] = $this->map($rule, $rawData);
+            $userdata[$property] = $data[$property][0];
+        }
+
+
+        $taouser = null;
+
+        // check if login already exists - Create if not, and add the delivery role!
+        $userService = \core_kernel_users_Service::singleton();
+
+        if (! $userService->loginExists($userdata[PROPERTY_USER_LOGIN])) {
+           $crudservice = new CrudService;
+           $taouser = $crudservice->CreateFromArray( $userdata );
+
+        } else {
+
+           // Retrieve the specified user.
+           $taouser = $userService->getOneUser( $userdata[PROPERTY_USER_LOGIN] );
+        }
+
+        return new LdapUser($taouser->getUri(), $data);
+    }
+
+    public function map($propertyConfig, $rawData) {
+        $data = array();
+        switch ($propertyConfig['type']) {
+            case 'value' :
+                $data = $propertyConfig['value'];
+                break;
+            case 'attributeValue' :
+                if (isset($rawData[$propertyConfig['attribute']])) {
+                    $value = $rawData[$propertyConfig['attribute']];
+                    $data = is_array($value) ? $value : array($value);
+                }
+                break;
+//            case 'conditionalvalue' :
+//                if (isset($rawData[$propertyConfig['attribute']]) &&
+//                    isset($rawData[$propertyConfig['attributematch']) ) {
+//                    // iterate raw data looking for attribute = attribute match
+//                    // set data = value property if determined to be true.
+//                }
+//                break;
+            case 'callback' :
+                if (isset($rawData[$propertyConfig['attribute']])) {
+                    $callback = $propertyConfig['callable'];
+                    if (is_callable($callback)) {
+                        $data = call_user_func($callback, $rawData[$propertyConfig['attribute']]);
+                    }
+                }
+                break;
+            default :
+                throw new \common_exception_InconsistentData('Unknown mapping: '.$propertyConfig['type']);
+        }
+        return $data;
+    }
+
+    public function getRules() {
+        $rules = self::getDefaultConfig();
+        foreach ($this->getOptions() as $key => $value) {
+            $rules[$key] = $value;
+        }
+        return $rules;
+    }
+
+    static public function getDefaultConfig()
+    {
+        return array(
+            PROPERTY_USER_ROLES         => self::rawValue(INSTANCE_ROLE_DELIVERY)
+            ,PROPERTY_USER_UILG         => self::rawValue(DEFAULT_LANG)
+            ,PROPERTY_USER_DEFLG        => self::rawValue(DEFAULT_LANG)
+            ,PROPERTY_USER_TIMEZONE     => self::rawValue(TIME_ZONE)
+            ,PROPERTY_USER_MAIL         => self::attributeValue('mail')
+            ,PROPERTY_USER_FIRSTNAME    => self::attributeValue('givenname')
+            ,PROPERTY_USER_LASTNAME     => self::attributeValue('sn')
+            ,PROPERTY_USER_LOGIN        => self::attributeValue('dn')
+            ,PROPERTY_USER_PASSWORD     => self::rawValue(CrudService::INVALID_PASSWORD)
+            ,RDFS_LABEL                 => self::attributeValue('mail')
+        );
+    }
+
+    static protected function rawValue($value) {
+        return array(
+            'type' => 'value',
+            'value' => array($value)
+        );
+    }
+
+    static protected function attributeValue($attributeName) {
+        return array(
+            'type' => 'attributeValue',
+            'attribute' => $attributeName
+        );
+    }
+
+    static protected function callback($callable, $attributeName) {
+        return array(
+            'type' => 'callback',
+            'callable' => $callable,
+            'attribute' => $attributeName
+        );
+    }
+}

--- a/model/LdapUserFactory.php
+++ b/model/LdapUserFactory.php
@@ -124,7 +124,7 @@ class LdapUserFactory extends Configurable {
             ,PROPERTY_USER_FIRSTNAME    => self::attributeValue('givenname')
             ,PROPERTY_USER_LASTNAME     => self::attributeValue('sn')
             ,PROPERTY_USER_LOGIN        => self::attributeValue('dn')
-            ,PROPERTY_USER_PASSWORD     => self::rawValue(CrudService::INVALID_PASSWORD)
+            ,PROPERTY_USER_PASSWORD     => self::rawValue('KLakjs892(*(761234987(*&')
             ,RDFS_LABEL                 => self::attributeValue('mail')
         );
     }

--- a/model/LdapUserFactory.php
+++ b/model/LdapUserFactory.php
@@ -58,10 +58,6 @@ class LdapUserFactory extends Configurable {
         $taouser = null;
 
         // check if login already exists - Create if not, and add the delivery role!
-        // $userService = ServiceManager::getServiceManager()->get("tao/UserService");
-        // $userService = \tao_models_classes_UserService::singleton();
-        // $userService = \core_kernel_users_Service::singleton();
-        // $userService = tao_models_classes_UserService::singleton();
 
         if (! \core_kernel_users_Service::loginExists($userdata[PROPERTY_USER_LOGIN])) {
            $crudservice = CrudService::singleton();


### PR DESCRIPTION
Ldap users are persisted on Logon into generis. 

This allows for results etc to render correctly. 

A minor patch is recommended to the user class to support the creation of "invalid" passwords to ensure that regardless of the authentication order the local logon will never be used (as it will always fail to authenticate)